### PR TITLE
Fixed wrong string format specifier for NSInteger and added casting t…

### DIFF
--- a/lib/Classes/Private/Networking/YXLHTTPClient.m
+++ b/lib/Classes/Private/Networking/YXLHTTPClient.m
@@ -123,7 +123,7 @@
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
         return [YXLErrorUtils errorWithCode:YXLErrorCodeRequestResponseError
-                                     reason:[NSString stringWithFormat:@"Bad status code %zd", httpResponse.statusCode]];
+                                     reason:[NSString stringWithFormat:@"Bad status code %ld", (long)httpResponse.statusCode]];
     }
     return nil;
 }


### PR DESCRIPTION
…o long

Project is not compiled for iPhone 5 (it has 32-bit architecture, so NSInteger needs some casting around).

![yxlhttpclient m 2018-08-01 15-46-07](https://user-images.githubusercontent.com/1327323/43522512-43626da2-95a2-11e8-9e93-e859ff2ffeb3.png)


